### PR TITLE
KA-505 Get rid of event type 'initialize'

### DIFF
--- a/kcd-webhook-service/eventComposer.js
+++ b/kcd-webhook-service/eventComposer.js
@@ -1,23 +1,13 @@
 const getUuid = require('uuid').v4;
 
 module.exports = (webhookBody, eventType, isTest) => {
-    const dataFromWebhook = eventType === 'kentico' ?
-        {
-            subject: webhookBody.message.operation,
-            data: webhookBody.data
-        } :
-        {
-            subject: eventType,
-            data: {}
-        };
-
     return {
         id: getUuid(),
-        isTest: isTest === 'true',
-        subject: dataFromWebhook.subject,
+        test: isTest === 'true',
+        subject: webhookBody.message.operation,
         eventType: eventType,
         dataVersion: '1.0',
-        data: dataFromWebhook.data,
+        data: webhookBody.data,
         eventTime: new Date()
     };
 };

--- a/kcd-webhook-service/eventComposer.test.js
+++ b/kcd-webhook-service/eventComposer.test.js
@@ -12,30 +12,16 @@ const webhookBody = {
 
 describe('eventComposer', () => {
     test('composes event with data from webhook', async () => {
-        const eventType = 'kentico';
+        const eventType = 'kentico-cloud';
         const isTest = undefined;
         const event = eventComposer(webhookBody, eventType, isTest);
 
         expect(event.id).toBeTruthy();
-        expect(event.isTest).toBe(false);
+        expect(event.test).toBe(false);
         expect(event.subject).toBe(webhookBody.message.operation);
         expect(event.eventType).toBe(eventType);
         expect(event.dataVersion).toBe('1.0');
         expect(event.data).toBe(webhookBody.data);
-        expect(event.eventTime).toBeTruthy();
-    });
-
-    test('composes event with invalid type', async () => {
-        const eventType = 'notKentico';
-        const isTest = undefined;
-        const event = eventComposer({}, eventType, isTest);
-
-        expect(event.id).toBeTruthy();
-        expect(event.isTest).toBe(false);
-        expect(event.subject).toBe(eventType);
-        expect(event.eventType).toBe(eventType);
-        expect(event.dataVersion).toBe('1.0');
-        expect(event.data).toEqual({});
         expect(event.eventTime).toBeTruthy();
     });
 
@@ -45,7 +31,7 @@ describe('eventComposer', () => {
         const event = eventComposer(webhookBody, eventType, isTest);
 
         expect(event.id).toBeTruthy();
-        expect(event.isTest).toBe(true);
+        expect(event.test).toBe(true);
         expect(event.subject).toBe(webhookBody.message.operation);
         expect(event.eventType).toBe(eventType);
         expect(event.dataVersion).toBe('1.0');
@@ -59,7 +45,7 @@ describe('eventComposer', () => {
         const event = eventComposer(webhookBody, eventType, isTest);
 
         expect(event.id).toBeTruthy();
-        expect(event.isTest).toBe(false);
+        expect(event.test).toBe(false);
         expect(event.subject).toBe(webhookBody.message.operation);
         expect(event.eventType).toBe(eventType);
         expect(event.dataVersion).toBe('1.0');

--- a/kcd-webhook-service/index.js
+++ b/kcd-webhook-service/index.js
@@ -4,7 +4,7 @@ const publishEventsCreator = require('./publishEventsCreator');
 const eventComposer = require('./eventComposer');
 
 module.exports = async (context, request) => {
-    if (request.query.source !== 'kentico' && request.query.source !== 'initialize') {
+    if (request.query.source !== 'kentico-cloud') {
         context.res = {
             status: 400,
             body: 'Request not valid'
@@ -13,7 +13,7 @@ module.exports = async (context, request) => {
         return;
     }
 
-    if (request.query.source === 'kentico' && request.body.message.type === 'content_item') {
+    if (request.body.message.type === 'content_item') {
         context.res = {
             status: 200,
             body: 'Nothing published'
@@ -26,7 +26,7 @@ module.exports = async (context, request) => {
     const eventGridClient = new EventGridClient(topicCredentials);
     const publishEvents = publishEventsCreator({ eventGridClient, host: process.env['EventGrid.DocsChanged.Endpoint'] });
 
-    await publishEvents([eventComposer(request.body, request.query.source, request.query.isTest)]);
+    await publishEvents([eventComposer(request.body, request.query.source, request.query.test)]);
 
     context.res = {
         status: 200,

--- a/kcd-webhook-service/index.test.js
+++ b/kcd-webhook-service/index.test.js
@@ -18,10 +18,10 @@ describe('Azure function fails', () => {
     expect(context.res.body).toBe('Request not valid');
   });
 
-  test('returns 200 but does nothing on kentico and content_item', async () => {
+  test('returns 200 but does nothing on kentico-cloud and content_item', async () => {
     const request = {
         query: {
-            source: 'kentico'
+            source: 'kentico-cloud'
         },
         body: {
             message: {


### PR DESCRIPTION
### Motivation

I removed the 'initialize' event support as it's no longer needed (KA-505).

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
