### PR TITLE
KA-515 Disable deploy stage for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ jobs:
       name: "Test"
       script: yarn test
     - stage: "Deployment"
-      if: branch = master OR branch = develop
+      if: type != pull_request AND (branch = master OR branch = develop)
       before_install: chmod +rx .travis/deploy.sh
       script: .travis/deploy.sh


### PR DESCRIPTION
### Motivation

Deployment stage for pull requests is extraneous and delays to build. (KA-515)

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Tests are passing
- [X] Documentation has been updated (if applicable)
- [X] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Verify that pull requests do not enter the deployment stage at all.
